### PR TITLE
Fix typo in home price label

### DIFF
--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -1,6 +1,6 @@
 <div class="mt-4 p-5 bg-primary text-white rounded">
   <h1>{{ stock.companyName }} ({{ stock.symbol }})</h1>
-  <p><strong>Lates Price: </strong>{{ stock.latestPrice }}<br/>
+  <p><strong>Latest Price: </strong>{{ stock.latestPrice }}<br/>
 <strong>Previous Close: </strong>{{ stock.previousClose }}<br/>
 <strong>Change Percent: </strong>{{ stock.changePercent }}<br/>
 <strong>Market Cap: </strong>{{ stock.marketCap }}<br/>


### PR DESCRIPTION
## Summary
- fix typo in home price label

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "const fs=require('fs'); const h=require('handlebars'); const t=fs.readFileSync('views/home.handlebars','utf8'); const c=h.compile(t); console.log(c({stock:{companyName:'ABC',symbol:'ABC',latestPrice:100,previousClose:98,changePercent:0.02,marketCap:123456,ytdChange:0.1,week52Low:80,week52High:120}}));" | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_688e829fe42c83298bdda3442f7e86b8