### PR TITLE
Fix handlebars layout configuration property

### DIFF
--- a/stock.js
+++ b/stock.js
@@ -28,7 +28,7 @@ request ('https://cloud.iexapis.com/stable/stock/' + ticker + '/quote?token=pk_0
 
 
 // set Handlebars
-app.engine('handlebars', engine({ extname:'.handlebars', defaultlayout: "main"}));
+app.engine('handlebars', engine({ extname:'.handlebars', defaultLayout: "main"}));
 app.set('view engine', 'handlebars');
 
 const otherstuff = "hello there, this is otherstuff!";


### PR DESCRIPTION
## Summary
- use `defaultLayout` option when registering express-handlebars

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_688e804a556c8329b1a32ea9dae6018d